### PR TITLE
API to return broadcast IP for an IPv4 address

### DIFF
--- a/common/ipprefix.h
+++ b/common/ipprefix.h
@@ -30,7 +30,7 @@ public:
         {
             case AF_INET:
             {
-                return IpAddress(ntohl(htonl(m_ip.getV4Addr()) | ~(htonl(getMask().getV4Addr()))));
+                return IpAddress((m_ip.getV4Addr()) | ~(getMask().getV4Addr()));
             }
             case AF_INET6:
             {

--- a/common/ipprefix.h
+++ b/common/ipprefix.h
@@ -26,11 +26,31 @@ public:
 
     inline IpAddress getBroadcastIp() const
     {
-        if(!isV4())
+        switch (m_ip.getIp().family)
         {
-            return m_ip;
+            case AF_INET:
+            {
+                return IpAddress(ntohl(htonl(m_ip.getV4Addr()) | ~(htonl(getMask().getV4Addr()))));
+            }
+            case AF_INET6:
+            {
+                ip_addr_t ipa;
+                ipa.family = AF_INET6;
+                const uint8_t *prefix = m_ip.getV6Addr();
+                IpAddress ip6mask = getMask();
+                const uint8_t *mask = ip6mask.getV6Addr();
+
+                for (int i = 0; i < 16; ++i)
+                {
+                    ipa.ip_addr.ipv6_addr[i] = (uint8_t)(prefix[i] | ~mask[i]);
+                }
+                return IpAddress(ipa);
+            }
+            default:
+            {
+                throw std::logic_error("Invalid family");
+            }
         }
-        return IpAddress(ntohl(htonl(m_ip.getV4Addr()) | ~(htonl(getMask().getV4Addr()))));
     }
 
     inline IpAddress getMask() const

--- a/common/ipprefix.h
+++ b/common/ipprefix.h
@@ -24,6 +24,15 @@ public:
         return m_ip;
     }
 
+    inline IpAddress getBroadcastIp() const
+    {
+        if(!isV4())
+        {
+            return m_ip;
+        }
+        return IpAddress(ntohl(htonl(m_ip.getV4Addr()) | ~(htonl(getMask().getV4Addr()))));
+    }
+
     inline IpAddress getMask() const
     {
         switch (m_ip.getIp().family)

--- a/tests/ipprefix_ut.cpp
+++ b/tests/ipprefix_ut.cpp
@@ -59,7 +59,7 @@ TEST(IpPrefix, ipv6)
     IpPrefix ipp128("2001:4898:f0:f153:357c:77b2:49c9:627c/128");
     EXPECT_EQ(ipp128.getIp().to_string(), "2001:4898:f0:f153:357c:77b2:49c9:627c");
     EXPECT_EQ(ipp128.getMask().to_string(), "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff");
-
+    
     EXPECT_THROW(IpPrefix("2001:4898:f0:f153:357c:77b2:49c9:627c/-1"), invalid_argument);
     EXPECT_THROW(IpPrefix("2001:4898:f0:f153:357c:77b2:49c9:627c/-2"), invalid_argument);
     EXPECT_THROW(IpPrefix("2001:4898:f0:f153:357c:77b2:49c9:627c/129"), invalid_argument);

--- a/tests/ipprefix_ut.cpp
+++ b/tests/ipprefix_ut.cpp
@@ -13,6 +13,14 @@ TEST(IpPrefix, ipv4)
     IpPrefix ip2("1.1.1.1/32");
     IpAddress mask2("255.255.255.255");
     EXPECT_EQ(ip2.getMask(), mask2);
+
+    IpPrefix ip3("192.168.0.1/27");
+    IpAddress bcast3("192.168.0.31");
+    EXPECT_EQ(ip3.getBroadcastIp(), bcast3);
+
+    IpPrefix ip4("10.1.1.1/24");
+    IpAddress bcast4("10.1.1.255");
+    EXPECT_EQ(ip4.getBroadcastIp(), bcast4);
 }
 
 TEST(IpPrefix, ipv6)
@@ -36,19 +44,22 @@ TEST(IpPrefix, ipv6)
     IpPrefix ipp64("2001:4898:f0:f153:357c:77b2:49c9:627c/64");
     EXPECT_EQ(ipp64.getIp().to_string(), "2001:4898:f0:f153:357c:77b2:49c9:627c");
     EXPECT_EQ(ipp64.getMask().to_string(), "ffff:ffff:ffff:ffff::");
+    EXPECT_EQ(ipp64.getBroadcastIp().to_string(), "2001:4898:f0:f153:ffff:ffff:ffff:ffff");
     
     IpPrefix ipp65("2001:4898:f0:f153:357c:77b2:49c9:627c/65");
     EXPECT_EQ(ipp65.getIp().to_string(), "2001:4898:f0:f153:357c:77b2:49c9:627c");
     EXPECT_EQ(ipp65.getMask().to_string(), "ffff:ffff:ffff:ffff:8000::");
+    EXPECT_EQ(ipp65.getBroadcastIp().to_string(), "2001:4898:f0:f153:7fff:ffff:ffff:ffff");
     
     IpPrefix ipp127("2001:4898:f0:f153:357c:77b2:49c9:627c/127");
     EXPECT_EQ(ipp127.getIp().to_string(), "2001:4898:f0:f153:357c:77b2:49c9:627c");
     EXPECT_EQ(ipp127.getMask().to_string(), "ffff:ffff:ffff:ffff:ffff:ffff:ffff:fffe");
+    EXPECT_EQ(ipp127.getBroadcastIp().to_string(), "2001:4898:f0:f153:357c:77b2:49c9:627d");
     
     IpPrefix ipp128("2001:4898:f0:f153:357c:77b2:49c9:627c/128");
     EXPECT_EQ(ipp128.getIp().to_string(), "2001:4898:f0:f153:357c:77b2:49c9:627c");
     EXPECT_EQ(ipp128.getMask().to_string(), "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff");
-    
+
     EXPECT_THROW(IpPrefix("2001:4898:f0:f153:357c:77b2:49c9:627c/-1"), invalid_argument);
     EXPECT_THROW(IpPrefix("2001:4898:f0:f153:357c:77b2:49c9:627c/-2"), invalid_argument);
     EXPECT_THROW(IpPrefix("2001:4898:f0:f153:357c:77b2:49c9:627c/129"), invalid_argument);


### PR DESCRIPTION
For an IPv4 address configured as 192.168.0.1/27, return broadcast address 192.168.0.31